### PR TITLE
If we overload "start" we can externalize the scripts

### DIFF
--- a/npm_scripts/build
+++ b/npm_scripts/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+npm start clean -s &&
+for cmd in npm_scripts/build_*; do echo $cmd; $cmd $*; done
+wait # for background jobs to finish

--- a/npm_scripts/build_markup
+++ b/npm_scripts/build_markup
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+jade assets/markup/index.jade --obj assets.json -o dist

--- a/npm_scripts/build_scripts
+++ b/npm_scripts/build_scripts
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+browserify -d assets/scripts/main.js -p [minifyify --compressPath . --map main.js.map --output dist/main.js.map] | \
+hashmark -n dist/main.js -s -l 8 -m assets.json 'dist/{name}{hash}{ext}'

--- a/npm_scripts/build_styles
+++ b/npm_scripts/build_styles
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+stylus assets/styles/main.styl -m -o dist/ &&
+hashmark -s -l 8 -m assets.json dist/main.css 'dist/{name}{hash}{ext}'

--- a/npm_scripts/clean
+++ b/npm_scripts/clean
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rimraf dist/*

--- a/npm_scripts/dev
+++ b/npm_scripts/dev
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for cmd in npm_scripts/{watch,live-reload,serve}; do echo $cmd; $cmd $* & done
+npm_scripts/open_dev
+wait # for background jobs to finish

--- a/npm_scripts/live-reload
+++ b/npm_scripts/live-reload
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+live-reload --port 9091 dist/

--- a/npm_scripts/open_dev
+++ b/npm_scripts/open_dev
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+opener http://localhost:9090

--- a/npm_scripts/serve
+++ b/npm_scripts/serve
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+http-server -p 9090 dist/

--- a/npm_scripts/start
+++ b/npm_scripts/start
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if test -f "npm_scripts/$1"
+then
+  exec npm_scripts/$*
+
+else
+  echo "Actual start script goes here"
+fi

--- a/npm_scripts/watch
+++ b/npm_scripts/watch
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+for cmd in npm_scripts/watch_*; do echo $cmd; $cmd $* & done
+wait # for background jobs to finish

--- a/npm_scripts/watch_build
+++ b/npm_scripts/watch_build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+nodemon -q -w assets/ --ext '.js' --exec 'npm start build'

--- a/npm_scripts/watch_test
+++ b/npm_scripts/watch_test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+karma start

--- a/package.json
+++ b/package.json
@@ -17,40 +17,15 @@
     "karma-mocha": "^0.1.10",
     "karma-phantomjs-launcher": "^0.1.4",
     "live-reload": "^0.2.0",
-    "minifyify": "^4.4.0",
+    "minifyify": "^6.1.1",
     "mocha": "^2.0.1",
-    "nodemon": "^1.2.1",
+    "nodemon": "^1.8.1",
     "opener": "^1.4.0",
-    "parallelshell": "^1.0.0",
     "rimraf": "^2.2.8",
-    "s3-cli": "^0.11.1",
     "stylus": "^0.49.3"
   },
   "scripts": {
-    "clean": "rimraf dist/*",
-
-    "prebuild": "npm run clean -s",
-    "build": "npm run build:scripts -s && npm run build:styles -s && npm run build:markup -s",
-    "build:scripts": "browserify -d assets/scripts/main.js -p [minifyify --compressPath . --map main.js.map --output dist/main.js.map] | hashmark -n dist/main.js -s -l 8 -m assets.json 'dist/{name}{hash}{ext}'",
-    "build:styles": "stylus assets/styles/main.styl -m -o dist/ && hashmark -s -l 8 -m assets.json dist/main.css 'dist/{name}{hash}{ext}'",
-    "build:markup": "jade assets/markup/index.jade --obj assets.json -o dist",
-
-    "test": "karma start --singleRun",
-
-    "watch": "parallelshell \"npm run watch:test -s\" \"npm run watch:build -s\"",
-    "watch:test": "karma start",
-    "watch:build": "nodemon -q -w assets/ --ext '.' --exec 'npm run build'",
-
-    "open:prod": "opener http://example.com",
-    "open:stage": "opener http://staging.example.internal",
-    "open:dev": "opener http://localhost:9090",
-
-    "deploy:prod": "s3-cli sync ./dist/ s3://example-com/prod-site/",
-    "deploy:stage": "s3-cli sync ./dist/ s3://example-com/stage-site/",
-
-    "serve": "http-server -p 9090 dist/",
-    "live-reload": "live-reload --port 9091 dist/",
-
-    "dev": "npm run open:dev -s && parallelshell \"npm run live-reload -s\" \"npm run serve -s\" \"npm run watch -s\""
+    "start": "npm_scripts/start",
+    "test": "karma start --singleRun"
   }
 }


### PR DESCRIPTION
- use shell to manipulate if/else/fail/success/background jobs etc
  - `"pre*"` provision from npm is interesting, but `&&` by shell is even better :-)
- code editor syntax highlight my build scripts
  - build scripts are now comment friendly too

e.g.
``` bash
npm start build
npm start dev
```

NOTE: pretty sure we can setup bash autocomplete with this too