### PR TITLE
Fix minifyify version to get 'npm run build:scripts' to run.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "karma-mocha": "^0.1.10",
     "karma-phantomjs-launcher": "^0.1.4",
     "live-reload": "^0.2.0",
-    "minifyify": "^4.4.0",
+    "minifyify": "^6.0.0",
     "mocha": "^2.0.1",
     "nodemon": "^1.2.1",
     "opener": "^1.4.0",


### PR DESCRIPTION
Got an error after these commands:

```
$ git clone https://github.com/keithamus/npm-scripts-example.git
$ cd npm-scripts-example/
$ npm install
$ npm run build
```

> npm-scripts-example@1.0.0 prebuild /Users/***/npm-scripts-example
> npm run clean -s


> npm-scripts-example@1.0.0 build /Users/***/npm-scripts-example
> npm run build:scripts -s && npm run build:styles -s && npm run build:markup -s

Error: not implemented
    at Readable._read (_stream_readable.js:450:22)
    at Readable.read (_stream_readable.js:329:10)
    at resume_ (_stream_readable.js:719:12)
    at nextTickCallbackWith2Args (node.js:475:9)
    at process._tickCallback (node.js:389:17)
    at Function.Module.runMain (module.js:449:11)
    at startup (node.js:140:18)
    at node.js:1001:3
  generated dist/main.css.map
  compiled dist/main.css

  rendered dist/index.html