### PR TITLE
FIX: Replace `parallelshell` by `npm-run-all`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "deploy:stage": "s3-cli sync ./dist/ s3://example-com/stage-site/",
     "serve": "http-server -p 9090 dist/",
     "live-reload": "live-reload --port=9091 --delay=1250 dist/",
-    "dev": "npm-run-all \"open:dev -s\" --parallel \"live-reload -s\" \"serve -s\" \"watch -s\""
+    "dev": "npm-run-all --parallel \"live-reload -s\" \"serve -s\" \"watch -s\" \"open:dev -s\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "minifyify": "^6.0.0",
     "mocha": "^2.0.1",
     "nodemon": "^1.2.1",
+    "npm-run-all": "^4.1.2",
     "opener": "^1.4.0",
-    "parallelshell": "^1.0.0",
     "rimraf": "^2.2.8",
     "s3-cli": "^0.11.1",
     "stylus": "^0.49.3"
@@ -32,29 +32,22 @@
   },
   "scripts": {
     "clean": "rimraf dist/*",
-
     "prebuild": "npm run clean -s",
     "build": "npm run build:scripts -s && npm run build:styles -s && npm run build:markup -s",
     "build:scripts": "browserify -d assets/scripts/main.js -p [minifyify --compressPath . --map main.js.map --output dist/main.js.map] | hashmark -n dist/main.js -s -l 8 -m assets.json \"dist/{name}{hash}{ext}\"",
     "build:styles": "stylus assets/styles/main.styl -m -o dist/ && hashmark -s -l 8 -m assets.json dist/main.css \"dist/{name}{hash}{ext}\"",
     "build:markup": "jade assets/markup/index.jade --obj assets.json -o dist",
-
     "test": "karma start --singleRun",
-
-    "watch": "parallelshell \"npm run watch:test -s\" \"npm run watch:build -s\"",
+    "watch": "npm-run-all --parallel \"watch:* -s\"",
     "watch:test": "karma start",
     "watch:build": "nodemon -q -w assets/ --ext \".\" --exec \"npm run build\"",
-
     "open:prod": "opener http://example.com",
     "open:stage": "opener http://staging.example.internal",
     "open:dev": "opener http://localhost:9090",
-
     "deploy:prod": "s3-cli sync ./dist/ s3://example-com/prod-site/",
     "deploy:stage": "s3-cli sync ./dist/ s3://example-com/stage-site/",
-
     "serve": "http-server -p 9090 dist/",
     "live-reload": "live-reload --port=9091 dist/",
-
-    "dev": "npm run open:dev -s && parallelshell \"npm run live-reload -s\" \"npm run serve -s\" \"npm run watch -s\""
+    "dev": "npm-run-all \"open:dev -s\" --parallel \"live-reload -s\" \"serve -s\" \"watch -s\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "deploy:prod": "s3-cli sync ./dist/ s3://example-com/prod-site/",
     "deploy:stage": "s3-cli sync ./dist/ s3://example-com/stage-site/",
     "serve": "http-server -p 9090 dist/",
-    "live-reload": "live-reload --port=9091 dist/",
+    "live-reload": "live-reload --port=9091 --delay=1250 dist/",
     "dev": "npm-run-all \"open:dev -s\" --parallel \"live-reload -s\" \"serve -s\" \"watch -s\""
   }
 }


### PR DESCRIPTION
@keithamus, for the npm script `dev`, I had an issue: the `open:dev` was ran before `serve` and so it was opening an error page instead of the demo...

I did try to run:

`npm-run-all --parallel \"live-reload -s\" \"serve -s\" \"watch -s\" --sequential \"open:dev -s\"`

I thought it would:
1. `live-reload` +`serve`+ `watch` in `--parallel`
2. Then run `open:dev` in `--sequential`

But it seems that `open:dev` never gets ran, I guess its is because the scripts running in parallel are "never done" until we hit `ctrl`+`c`...

So I did it all in parallel like so:

`npm-run-all --parallel \"live-reload -s\" \"serve -s\" \"watch -s\" \"open:dev -s\"`

What do you think about it ?

PS: I also had to downgrade my installs in order to run `karma` to:
`node: 6.9.5` + `npm 3.10.10` (`nvm` FTW)